### PR TITLE
Added ability to download Ivy settings through URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.410</version>
+        <version>1.424</version>
     </parent>
 
     <artifactId>ivytrigger</artifactId>

--- a/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/help-ivySettingsPath.html
+++ b/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/help-ivySettingsPath.html
@@ -1,6 +1,7 @@
 <div>
     <p>
         Give the path of an ivySetting.xml file.<br/>
-        The path can be absolute or relative to the workspace of the latest build.
+        The path can be absolute or relative to the workspace of the latest build
+        or it can be an URL to retrieve/download.
     </p>
 </div>


### PR DESCRIPTION
In our organization we use Ivy settings file, located on the HTTP server, holding the whole Ivy repository. As a result, it is not possible to use the file in the IvyTrigger plugin. This request adds the ability to make Ivy settings file to be downloaded from URL instead of loading file stored on a Jenkins machine.
