### PR TITLE
Added option to control whether or not artifacts are downloaded

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ivytrigger/IvyTriggerEvaluator.java
+++ b/src/main/java/org/jenkinsci/plugins/ivytrigger/IvyTriggerEvaluator.java
@@ -176,7 +176,9 @@ public class IvyTriggerEvaluator implements FilePath.FileCallable<Map<String, Iv
                 final String result = IOUtils.toString(is);
                 return result;
             } finally {
-                is.close();
+                if ( is != null ) {
+                    is.close();
+                }
             }
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/config.jelly
@@ -23,6 +23,11 @@
         <f:checkbox name="debug" checked="${instance.debug}"/>
     </f:entry>
 
+    <f:entry field="downloadArtifacts"
+             title="${%Download artifacts for dependencies to see if they have changed}">
+        <f:checkbox name="downloadArtifacts" checked="${instance.downloadArtifacts}" default="true"/>
+    </f:entry>
+
     <f:entry field="enableConcurrentBuild" title="${%Enable Concurrent Build}">
         <f:checkbox name="enableConcurrentBuild" checked="${instance.enableConcurrentBuild}"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/help-downloadArtifacts.html
+++ b/src/main/resources/org/jenkinsci/plugins/ivytrigger/IvyTrigger/help-downloadArtifacts.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Whether or not to download the artifacts within a dependency.<br/>
+        If this is false, then much less disk space is used. However a change in the
+        artifacts, or the addition or removal of artifacts, of a dependency that does
+        not <strong>also</strong> cause a version number change in the dependency
+        will not be detected.
+    </p>
+</div>


### PR DESCRIPTION
There is a new option (downloadArtifacts) that controls whether or not
artifacts are downloaded. If they are (the default to maintain backwards
compatibility) then the trigger will check to see if any artifacts inside
a dependency have changed with out changing the version number.

If artifacts are not configured for download, the trigger only checks to
make sure the resolved dependency version has not changed.

Fixes JENKINS-28044